### PR TITLE
add hsl color attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add base error class (`Chroma::Error`).
 * Change namespace for errors from `Chroma::Errors::` to `Chroma::`.
 * Add red, green and blue color attributes
+* Add hue, saturation, lightness color attributes
 
 ## v0.1.0 - 2016-05-26
 

--- a/lib/chroma/color/attributes.rb
+++ b/lib/chroma/color/attributes.rb
@@ -49,6 +49,18 @@ module Chroma
         @rgb.b
       end
 
+      def hue
+        Chroma::Converters::HslConverter.convert_rgb(@rgb).h
+      end
+
+      def saturation
+        Chroma::Converters::HslConverter.convert_rgb(@rgb).s
+      end
+
+      def lightness
+        Chroma::Converters::HslConverter.convert_rgb(@rgb).l
+      end
+
       # Calculates the brightness.
       #
       # @example

--- a/spec/color/attributes_spec.rb
+++ b/spec/color/attributes_spec.rb
@@ -68,6 +68,36 @@ describe Chroma::Color do
     end
   end
 
+  describe '#hue' do
+    it 'returns the correct hue value' do
+      expect('rgba(255, 0, 75, 0.75)'.paint.hue).to eq 342.3529411764706
+      expect('#ff00cc80'.paint.hue).to              eq 312.0
+      expect('transparent'.paint.hue).to            eq 0
+      expect('hsla(266, 100%, 25%, 0'.paint.hue).to eq 266.0
+      expect(red.hue).to                            eq 0
+    end
+  end
+
+  describe '#saturation' do
+    it 'returns the correct saturation value' do
+      expect('rgba(212, 26, 75, 0.75)'.paint.saturation).to eq 0.7815126050420169
+      expect('#ff00cc80'.paint.saturation).to               eq 1.0
+      expect('transparent'.paint.saturation).to             eq 0
+      expect('hsla(266, 95%, 25%, 0'.paint.saturation).to   eq 0.95
+      expect(black.saturation).to                           eq 0
+    end
+  end
+
+  describe '#lightness' do
+    it 'returns the correct lightness value' do
+      expect('rgba(187, 30, 75, 0.75)'.paint.lightness).to eq 0.42549019607843136
+      expect('#ff00cc80'.paint.lightness).to               eq 0.5
+      expect('transparent'.paint.lightness).to             eq 0
+      expect('hsla(266, 100%, 25%, 0'.paint.lightness).to  eq 0.25
+      expect(black.lightness).to                           eq 0
+    end
+  end
+
   describe '#brightness' do
     it 'returns the correct brightness' do
       expect(red.brightness).to    eq 76.245


### PR DESCRIPTION
Adds HSL attributes to color.

Some follow up work:

- [ ] See about memoizing the conversion to HSL
- [ ] Determine what level of precision we want to report, and when to use percentages

cc @Thibaut 